### PR TITLE
Testing Pull Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 Details of the model can be found in the PDF titled "Final Report".
 
 main.ipynb has the code that implements the model. The file can be run in Jupyter Notebooks (with Julia).
+
+
+(Testing Pull Requests)


### PR DESCRIPTION
Added the flag USE_NEW_MCTS in run_scheduler.py. Currently, due to renaming of the "transition" function, the new MCTS code from miso_mcts does not currently run with run_scheduler.py. Set USE_NEW_MCTS to False until that is fixed.